### PR TITLE
Add detection for non-glibc libc on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "async": "^2.1.4",
+    "detect-libc": "^1.0.3",
     "execspawn": "^1.0.1",
     "ghreleases": "^1.0.2",
     "github-from-package": "0.0.0",

--- a/rc.js
+++ b/rc.js
@@ -1,11 +1,14 @@
 var minimist = require('minimist')
 var targets = require('node-abi').supportedTargets
+var detectLibc = require('detect-libc')
+
+var libc = process.env.LIBC || (detectLibc.isNonGlibcLinux && detectLibc.family) || ''
 
 var rc = require('rc')('prebuild', {
   target: process.versions.node,
   runtime: 'node',
   arch: process.arch,
-  libc: process.env.LIBC,
+  libc: libc,
   platform: process.platform,
   all: false,
   force: false,

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -16,7 +16,8 @@ test('custom config and aliases', function (t) {
     '--path ../some/other/path',
     '--preinstall somescript.js',
     '--target 13',
-    '--runtime electron'
+    '--runtime electron',
+    '--libc testlibc'
   ]
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc.all, false, 'default is not building all targets')
@@ -40,6 +41,7 @@ test('custom config and aliases', function (t) {
     t.equal(rc.target, rc.t, 'target alias')
     t.equal(rc.runtime, 'electron', 'correct runtime')
     t.equal(rc.runtime, rc.r, 'runtime alias')
+    t.equal(rc.libc, 'testlibc', 'libc family')
     t.end()
   })
 })


### PR DESCRIPTION
Hello, here's an initial attempt to integrate *automagic* libc detection via [detect-libc](https://www.npmjs.com/package/detect-libc), as discussed in #149.

It will only set the `libc` option if not already done so via command line or environment variable, and then only when run on a non-glibc Linux to ensure backwards compatibility with the implicit default of glibc.

There were no existing libc related tests so guidance on where best to add these, if any, is most welcome.