### PR TITLE
add support for 'format' command line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ loaded:
 prebuild-install --binary-name main-binary.node
 ```
 
+The build file format is selected automatically by `node-gyp`, however it is possible to specify needed format explicitly with `--format` parameter.
+This is particularly useful if unusual flavor is required, which could be specified in 'format-flavor' form
+(there is no comprehensive list of formats/flavors available so one has to find possible combinations from `node-gyp` source code).
+For example, in order to build using Makefiles but assume Android cross-compilation:
+
+```
+prebuild --format make-android
+```
+
 ## Uploading
 
 `prebuild` supports uploading prebuilds to GitHub releases. If the release doesn't exist, it will be created for you. To upload prebuilds simply add the `-u <github-token>` option:

--- a/gypbuild.js
+++ b/gypbuild.js
@@ -30,6 +30,8 @@ function runGyp (opts, target, cb) {
     }
     if (opts.debug) args.push('--debug')
 
+    if (opts.format) args.push('--', '--format', opts.format)
+
     gyp({
       gyp: opts.gyp,
       backend: opts.backend,

--- a/rc.js
+++ b/rc.js
@@ -16,6 +16,7 @@ var rc = require('rc')('prebuild', {
   verbose: false,
   path: '.',
   backend: 'node-gyp',
+  format: false,
   'include-regex': '\\.node$'
 }, minimist(process.argv, {
   alias: {

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -17,7 +17,8 @@ test('custom config and aliases', function (t) {
     '--preinstall somescript.js',
     '--target 13',
     '--runtime electron',
-    '--libc testlibc'
+    '--libc testlibc',
+    '--format msvs'
   ]
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc.all, false, 'default is not building all targets')
@@ -42,6 +43,7 @@ test('custom config and aliases', function (t) {
     t.equal(rc.runtime, 'electron', 'correct runtime')
     t.equal(rc.runtime, rc.r, 'runtime alias')
     t.equal(rc.libc, 'testlibc', 'libc family')
+    t.equal(rc.format, 'msvs', 'correct node-gyp format')
     t.end()
   })
 })


### PR DESCRIPTION
Pass through 'format' parameter which is handled by node-gyp configure step
(https://github.com/nodejs/node-gyp/blob/master/lib/configure.js#L216)