### PR TITLE
Reduce compressed tarball size by ~1%

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -27,7 +27,7 @@ function pack (filename, tarPath, cb) {
         tarStream.finalize()
       })
 
-      tarStream.pipe(zlib.createGzip()).pipe(ws).on('close', cb)
+      tarStream.pipe(zlib.createGzip({ level: 9 })).pipe(ws).on('close', cb)
     })
   })
 }


### PR DESCRIPTION
Hello, the change in this PR offers a quick win to very slightly reduce the output compressed tarball size and therefore very slightly improve tarball download and decompression time.

By way of example, here are the before and after sizes for the latest leveldown binaries:

Before:
```
175256 leveldown-v2.0.0-node-v57-darwin-x64.tar.gz
211712 leveldown-v2.0.0-node-v57-linux-x64.tar.gz
211979 leveldown-v2.0.0-node-v57-win32-ia32.tar.gz
247942 leveldown-v2.0.0-node-v57-win32-x64.tar.gz
```

After:
```
174325 leveldown-v2.0.0-node-v57-darwin-x64.tar.gz
208189 leveldown-v2.0.0-node-v57-linux-x64.tar.gz
211251 leveldown-v2.0.0-node-v57-win32-ia32.tar.gz
246791 leveldown-v2.0.0-node-v57-win32-x64.tar.gz
```