### PR TITLE
downgrade nsp for node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "a-native-module": "^1.0.0",
-    "nsp": "^3.1.0",
+    "nsp": "^2.8.1",
     "rimraf": "^2.4.2",
     "standard": "^10.0.3",
     "tape": "^4.0.1"


### PR DESCRIPTION
This is only devDependencies so no biggie. I tried to get a PR through to `nsp` to remove stupid destructuring issue, but it was rejected.