### PR TITLE
Added fix for building node 10

### DIFF
--- a/gypbuild.js
+++ b/gypbuild.js
@@ -16,6 +16,9 @@ function runGyp (opts, target, cb) {
     args.push('--dist-url=https://atom.io/download/electron')
   } else if (opts.runtime === 'node-webkit') {
     args.push('--runtime=node-webkit')
+  } else if (opts.runtime === 'node') {
+    // work around bug introduced in node 10's build https://github.com/nodejs/node-gyp/issues/1457
+    args.push('--build_v8_with_gn=false')
   }
   if (opts.debug) args.push('--debug')
 


### PR DESCRIPTION
This variable was added to node 10's build process and is automatically set when building with node 10 but not on older version of node's. Older nodes ignore the flag.

Reference https://github.com/nodejs/node-gyp/issues/1457

Closes https://github.com/prebuild/prebuild/issues/222