### PR TITLE
fix(rc): don't overwrite user-provided upload token

### DIFF
--- a/rc.js
+++ b/rc.js
@@ -56,10 +56,6 @@ if (rc.all === true) {
   rc.prebuild = targets
 }
 
-if (rc['upload-all']) {
-  rc.upload = rc['upload-all']
-}
-
 rc['include-regex'] = new RegExp(rc['include-regex'], 'i')
 
 module.exports = rc


### PR DESCRIPTION
This check rewrites the `upload` variable to be a boolean if
upload-all was specified. This will wipe out the user-provided
github auth token if one was indeed provided, and will fail all
subsequent attempts to upload the prebuilds.