### PR TITLE
Work around build issue when targeting node 11

### DIFF
--- a/gypbuild.js
+++ b/gypbuild.js
@@ -24,6 +24,8 @@ function runGyp (opts, target, cb) {
   } else if (opts.runtime === 'node') {
     // work around bug introduced in node 10's build https://github.com/nodejs/node-gyp/issues/1457
     args.push('--build_v8_with_gn=false')
+    // work around the same kind of bug for node 11
+    args.push('--enable_lto=false')
   }
   if (opts.debug) args.push('--debug')
 


### PR DESCRIPTION
Same kind of issue as bf45b46aadd80544eb792877eb73ac5781c14b34.

With this and lgeiger/node-abi#51, we can haz prebuilds for Node.js 11.x 🎉