### PR TITLE
Recursively list files in the build directory when collecting artefacts

### DIFF
--- a/collect-artifacts.js
+++ b/collect-artifacts.js
@@ -1,10 +1,7 @@
-var fs = require('fs')
-var path = require('path')
 var error = require('./error')
-var recursive = require("recursive-readdir")
+var recursive = require('recursive-readdir')
 
 module.exports = collectArtifacts
-
 
 function collectArtifacts (release, opts, cb) {
   var fileExp = opts['include-regex']

--- a/collect-artifacts.js
+++ b/collect-artifacts.js
@@ -9,7 +9,7 @@ function collectArtifacts (release, opts, cb) {
     if (err) return cb(err)
 
     var collected = files.filter(function filterByRegex (filename) {
-      return fileExp.test(filename)
+      return fileExp.test(filename.substring(release.length + 1))
     })
 
     if (!collected.length) {

--- a/collect-artifacts.js
+++ b/collect-artifacts.js
@@ -1,46 +1,24 @@
 var fs = require('fs')
 var path = require('path')
 var error = require('./error')
+var recursive = require("recursive-readdir")
 
 module.exports = collectArtifacts
 
-function readDirRecursiveSync(directory, relativeDir) {
-  relativeDir = relativeDir || '';
-  var collected
-  var files = fs.readdirSync(directory, {withFileTypes: true})
-  collected = files.map(function filterFiles(dirEnt){
-    if(dirEnt.isFile()) return path.join(relativeDir, dirEnt.name)
-  })
-  collected = collected.concat(files.map(function filterFiles(dirEnt){
-    if(dirEnt.isDirectory()) return readDirRecursiveSync(path.join(directory, dirEnt.name), path.join(relativeDir, dirEnt.name))
-  }))
-  return collected.reduce(function flatten(acc, file) {
-    if(Array.isArray(file)){
-      acc = acc.concat(file)
-    } else if(file) {
-      acc.push(file)
-    }
-    return acc
-  }, [])
-}
 
 function collectArtifacts (release, opts, cb) {
   var fileExp = opts['include-regex']
-  var files = readDirRecursiveSync(release)
-  try {
-    files = readDirRecursiveSync(release)
-  } catch(err){
-    return cb(err)
-  }
-  var collected = files.filter(function filterByRegex (filename) {
-    return fileExp.test(filename)
-  }).map(function addPath (filename) {
-    return path.join(release, filename)
+  recursive(release, function (err, files) {
+    if (err) return cb(err)
+
+    var collected = files.filter(function filterByRegex (filename) {
+      return fileExp.test(filename)
+    })
+
+    if (!collected.length) {
+      return cb(error.noBuild(release))
+    }
+
+    cb(null, collected)
   })
-
-  if (!collected.length) {
-    return cb(error.noBuild(release))
-  }
-
-  cb(null, collected)
 }

--- a/collect-artifacts.js
+++ b/collect-artifacts.js
@@ -1,3 +1,4 @@
+var path = require('path')
 var error = require('./error')
 var recursive = require('recursive-readdir')
 
@@ -9,7 +10,7 @@ function collectArtifacts (release, opts, cb) {
     if (err) return cb(err)
 
     var collected = files.filter(function filterByRegex (filename) {
-      return fileExp.test(filename.substring(release.length + 1))
+      return fileExp.test(path.relative(release, filename))
     })
 
     if (!collected.length) {

--- a/collect-artifacts.js
+++ b/collect-artifacts.js
@@ -4,21 +4,43 @@ var error = require('./error')
 
 module.exports = collectArtifacts
 
+function readDirRecursiveSync(directory, relativeDir) {
+  relativeDir = relativeDir || '';
+  var collected
+  var files = fs.readdirSync(directory, {withFileTypes: true})
+  collected = files.map(function filterFiles(dirEnt){
+    if(dirEnt.isFile()) return path.join(relativeDir, dirEnt.name)
+  })
+  collected = collected.concat(files.map(function filterFiles(dirEnt){
+    if(dirEnt.isDirectory()) return readDirRecursiveSync(path.join(directory, dirEnt.name), path.join(relativeDir, dirEnt.name))
+  }))
+  return collected.reduce(function flatten(acc, file) {
+    if(Array.isArray(file)){
+      acc = acc.concat(file)
+    } else if(file) {
+      acc.push(file)
+    }
+    return acc
+  }, [])
+}
+
 function collectArtifacts (release, opts, cb) {
   var fileExp = opts['include-regex']
-  fs.readdir(release, function (err, files) {
-    if (err) return cb(err)
-
-    var collected = files.filter(function filterByRegex (filename) {
-      return fileExp.test(filename)
-    }).map(function addPath (filename) {
-      return path.join(release, filename)
-    })
-
-    if (!collected.length) {
-      return cb(error.noBuild(release))
-    }
-
-    cb(null, collected)
+  var files = readDirRecursiveSync(release)
+  try {
+    files = readDirRecursiveSync(release)
+  } catch(err){
+    return cb(err)
+  }
+  var collected = files.filter(function filterByRegex (filename) {
+    return fileExp.test(filename)
+  }).map(function addPath (filename) {
+    return path.join(release, filename)
   })
+
+  if (!collected.length) {
+    return cb(error.noBuild(release))
+  }
+
+  cb(null, collected)
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "nw-gyp": "^3.6.3",
     "osenv": "^0.1.4",
     "rc": "^1.0.3",
+    "recursive-readdir": "^2.2.2",
     "tar-stream": "^1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I have a module where I need to distribute a 3rd party DLL along with the .node library, and it has a specific directory structure that needs to be replicated .

Currently collecting artefacts list files in only one level deep. 
This PR changes the file listing to be recursive, allowing any kind of directory structure to be included in the prebuilt package.