### PR TITLE
bump to latest node-abi (Node 12/Electron 5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",
     "napi-build-utils": "^1.0.1",
-    "node-abi": "^2.2.0",
+    "node-abi": "^2.8.0",
     "node-gyp": "^3.0.3",
     "node-ninja": "^1.0.1",
     "noop-logger": "^0.1.0",


### PR DESCRIPTION
https://github.com/lgeiger/node-abi/pull/62 adds support for detecting Electron 5 and Node 12