### PR TITLE
Pin cmake-js to ~5.2.0 to fix building on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "async": "^2.1.4",
-    "cmake-js": "^5.2.0",
+    "cmake-js": "~5.2.0",
     "detect-libc": "^1.0.3",
     "execspawn": "^1.0.1",
     "ghreleases": "^2.0.0",


### PR DESCRIPTION
Some change between `cmake-js` 5.2.0 and 5.3.0 broke our AppVeyor tests ([logs](https://ci.appveyor.com/project/mathiask88/prebuild/builds/25930825/job/6tciae0pajf6a36r)), as well as locally on my machine. See https://github.com/cmake-js/cmake-js/issues/186.