### PR TITLE
Unlock cmake-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "n-api"
   ],
   "dependencies": {
-    "cmake-js": "~5.2.0",
+    "cmake-js": "^5.3.2",
     "detect-libc": "^1.0.3",
     "each-series-async": "^1.0.1",
     "execspawn": "^1.0.1",

--- a/test/integration-cmake-test.js
+++ b/test/integration-cmake-test.js
@@ -6,46 +6,43 @@ var rm = require('rimraf')
 
 var cwd = path.join(__dirname, 'native-module-cmake')
 
-// See https://github.com/cmake-js/cmake-js/issues/186
-if (process.platform !== 'win32' || process.arch !== 'ia32') {
-  test('can prebuild a cmake-js native module for node', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake-js native module for node', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
+  console.log()
+  exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
+})
 
-  test('can prebuild a cmake-js native module for electron', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-electron-v50-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild-electron', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake-js native module for electron', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-electron-v50-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
+  console.log()
+  exec('npm run prebuild-electron', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
+})
 
-  test('can prebuild a cmake-js native module for node with silent argument', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild-silent', { cwd: cwd }, function (error, stdout, stderr) {
-      // XXX: latest cmake-js has a forgotten console.log(process.argv)
-      t.ok(stdout.trim().split('\n').length <= 12, 'stdout should be silent')
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake-js native module for node with silent argument', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
+  console.log()
+  exec('npm run prebuild-silent', { cwd: cwd }, function (error, stdout, stderr) {
+    // XXX: latest cmake-js has a forgotten console.log(process.argv)
+    t.ok(stdout.trim().split('\n').length <= 12, 'stdout should be silent')
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
-}
+})

--- a/test/integration-napi-cmake-test.js
+++ b/test/integration-napi-cmake-test.js
@@ -6,31 +6,28 @@ var rm = require('rimraf')
 
 var cwd = path.join(__dirname, 'native-module-napi-cmake')
 
-// See https://github.com/cmake-js/cmake-js/issues/186
-if (process.platform !== 'win32' || process.arch !== 'ia32') {
-  test('can prebuild a cmake napi module for node', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake napi module for node', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
+  console.log()
+  exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
+})
 
-  test('can prebuild a cmake napi module for node with prepack script', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild-prepack', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake napi module for node with prepack script', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
+  console.log()
+  exec('npm run prebuild-prepack', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
-}
+})


### PR DESCRIPTION
Undoes #251, because https://github.com/cmake-js/cmake-js/pull/187 (5.3.1) fixed builds on Windows.