### PR TITLE
Upgrade dependencies and add node 12 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 
 matrix:
   include:
-  - node_js: '11'
+  - node_js: '12'
     os: linux
   - node_js: '10'
     os: linux
@@ -10,7 +10,7 @@ matrix:
     os: linux
   - node_js: '6'
     os: linux
-  - node_js: '11'
+  - node_js: '12'
     os: osx
   - node_js: '10'
     os: osx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ version: "{build}"
 environment:
   # Test against these versions of Node.js
   matrix:
-    - nodejs_version: "11"
+    - nodejs_version: "12"
     - nodejs_version: "10"
     - nodejs_version: "8"
     - nodejs_version: "6"

--- a/bin.js
+++ b/bin.js
@@ -3,7 +3,7 @@
 var path = require('path')
 var log = require('npmlog')
 var fs = require('fs')
-var async = require('async')
+var eachSeries = require('each-series-async')
 var napi = require('napi-build-utils')
 
 var pkg = require(path.resolve('package.json'))
@@ -52,7 +52,7 @@ if (opts['upload-all']) {
   })
 } else {
   var files = []
-  async.eachSeries(opts.prebuild, function (target, next) {
+  eachSeries(opts.prebuild, function (target, next) {
     prebuild(opts, target.target, target.runtime, function (err, tarGz) {
       if (err) return next(err)
       files.push(tarGz)

--- a/pack.js
+++ b/pack.js
@@ -1,4 +1,4 @@
-var async = require('async')
+var eachSeries = require('each-series-async')
 var fs = require('fs')
 var path = require('path')
 var mkdirp = require('mkdirp')
@@ -19,7 +19,7 @@ function pack (filenames, tarPath, cb) {
     var ws = fs.createWriteStream(tarPath)
     tarStream.pipe(zlib.createGzip({ level: 9 })).pipe(ws)
 
-    async.eachSeries(filenames, function processFile (filename, nextFile) {
+    eachSeries(filenames, function processFile (filename, nextFile) {
       fs.stat(filename, function (err, st) {
         if (err) return nextFile(err)
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "detect-libc": "^1.0.3",
     "each-series-async": "^1.0.1",
     "execspawn": "^1.0.1",
-    "ghreleases": "^2.0.0",
+    "ghreleases": "^3.0.2",
     "github-from-package": "0.0.0",
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "n-api"
   ],
   "dependencies": {
-    "async": "^2.1.4",
     "cmake-js": "~5.2.0",
     "detect-libc": "^1.0.3",
+    "each-series-async": "^1.0.1",
     "execspawn": "^1.0.1",
     "ghreleases": "^2.0.0",
     "github-from-package": "0.0.0",
@@ -39,6 +39,7 @@
     "nw-gyp": "^3.6.3",
     "osenv": "^0.1.4",
     "rc": "^1.0.3",
+    "run-waterfall": "^1.1.6",
     "tar-stream": "^1.2.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "osenv": "^0.1.4",
     "rc": "^1.0.3",
     "run-waterfall": "^1.1.6",
-    "tar-stream": "^1.2.1"
+    "tar-stream": "^2.1.0"
   },
   "devDependencies": {
     "a-native-module": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^3.0.0",
     "standard": "^13.0.1",
     "tape": "^4.0.1",
-    "verify-travis-appveyor": "^2.0.1"
+    "verify-travis-appveyor": "^3.0.1"
   },
   "bin": {
     "prebuild": "./bin.js"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "a-native-module": "^1.0.0",
-    "rimraf": "^2.4.2",
+    "rimraf": "^3.0.0",
     "standard": "^13.0.1",
     "tape": "^4.0.1",
     "verify-travis-appveyor": "^2.0.1"

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,5 +1,5 @@
 var fs = require('fs')
-var async = require('async')
+var waterfall = require('run-waterfall')
 var getAbi = require('node-abi').getAbi
 var getTarget = require('node-abi').getTarget
 var napi = require('napi-build-utils')
@@ -59,7 +59,7 @@ function prebuild (opts, target, runtime, callback) {
       })
     }
 
-    async.waterfall(tasks, callback)
+    waterfall(tasks, callback)
   })
 }
 


### PR DESCRIPTION
I intend for this to be included in a 9.1.0 release. Upgraded all dependencies except for `node-gyp` (deserves more scrutiny and probably a major bump here) and `cmake-js` (see #254).