### PR TITLE
Fix node-gyp cache conflict between node and electron

### DIFF
--- a/gyp.js
+++ b/gyp.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 var path = require('path')
-var osenv = require('osenv')
+var os = require('os')
 
 var backends = {
   'node-gyp': require('node-gyp')(),
@@ -25,7 +25,7 @@ function runGyp (opts, cb) {
 
   log.verbose('execute ' + backend + ' with `' + args.join(' ') + '`')
   gyp.parseArgv(args)
-  gyp.devDir = devDir()
+  gyp.devDir = devDir(opts.runtime || 'node')
 
   function runStep () {
     var command = gyp.todo.shift()
@@ -61,8 +61,11 @@ function runGyp (opts, cb) {
   }
 }
 
-function devDir () {
-  return path.resolve(osenv.home(), '.node-gyp')
+function devDir (runtime) {
+  // Since electron and node are reusing the versions now (fx 6.0.0) and
+  // node-gyp only uses the version to store the dev files, they have started
+  // clashing. To work around this we explicitly set devdir to tmpdir/runtime(/target)
+  return path.join(os.tmpdir(), 'prebuild', runtime)
 }
 
 module.exports = runGyp

--- a/gypbuild.js
+++ b/gypbuild.js
@@ -33,6 +33,7 @@ function runGyp (opts, target, cb) {
 
   gyp({
     gyp: opts.gyp,
+    runtime: opts.runtime,
     backend: opts.backend,
     log: opts.log,
     args: args,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "npm-which": "^3.0.1",
     "npmlog": "^4.0.1",
     "nw-gyp": "^3.6.3",
-    "osenv": "^0.1.4",
     "rc": "^1.0.3",
     "run-waterfall": "^1.1.6",
     "tar-stream": "^2.1.0"

--- a/test/gypbuild-test.js
+++ b/test/gypbuild-test.js
@@ -3,7 +3,8 @@ var runGyp = require('../gypbuild')
 var build = require('../build')
 var util = require('../util')
 var noop = require('noop-logger')
-var osenv = require('osenv')
+var path = require('path')
+var os = require('os')
 
 test('gyp is invoked with correct arguments, release mode', function (t) {
   t.plan(7)
@@ -46,7 +47,7 @@ test('gyp is invoked with correct arguments, release mode', function (t) {
   }
   runGyp(opts, 'x.y.z', function (err) {
     var devDir = opts.gyp.devDir
-    t.equal(devDir.indexOf(osenv.home()), 0, devDir + ' should start with home folder')
+    t.is(devDir, path.join(os.tmpdir(), 'prebuild', 'node'))
     t.error(err, 'no error')
   })
 })


### PR DESCRIPTION
Adapted from `prebuildify`. Closes #249.