### PR TITLE
Update node-gyp to 6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mkdirp": "^0.5.1",
     "napi-build-utils": "^1.0.1",
     "node-abi": "^2.2.0",
-    "node-gyp": "^3.0.3",
+    "node-gyp": "^5.0.7",
     "node-ninja": "^1.0.1",
     "noop-logger": "^0.1.0",
     "npm-which": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mkdirp": "^0.5.1",
     "napi-build-utils": "^1.0.1",
     "node-abi": "^2.2.0",
-    "node-gyp": "^5.0.7",
+    "node-gyp": "^6.0.1",
     "node-ninja": "^1.0.1",
     "noop-logger": "^0.1.0",
     "npm-which": "^3.0.1",


### PR DESCRIPTION
I didn't find anyone talking about this in the issues, so maybe this PR will spark some conversation.

I didn't personally run into issues while doing this in my project:

```
cd node_modules/prebuild && npm i node-gyp@5
```

Breaking changes in 5.x: https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md#v500-2019-06-13
Breaking changes in 4.x: https://github.com/nodejs/node-gyp/blob/master/CHANGELOG.md#v400-2019-04-24

---

Any chance the version of `node-gyp` could be configurable? 