### PR TITLE
Support namespaced packages in upload-all

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -5,6 +5,7 @@ var log = require('npmlog')
 var fs = require('fs')
 var eachSeries = require('each-series-async')
 var napi = require('napi-build-utils')
+var glob = require('glob')
 
 var pkg = require(path.resolve('package.json'))
 var rc = require('./rc')
@@ -41,9 +42,9 @@ var opts = Object.assign({}, rc, { pkg: pkg, log: log, buildLog: buildLog, argv:
 if (napi.isNapiRuntime(rc.runtime)) napi.logMissingNapiVersions(rc.target, rc.prebuild, log)
 
 if (opts['upload-all']) {
-  fs.readdir('prebuilds', function (err, pbFiles) {
+  glob('prebuilds/**/*', { nodir: true }, function (err, pbFiles) {
     if (err) return onbuilderror(err)
-    uploadFiles(pbFiles.map(function (file) { return 'prebuilds/' + file }))
+    uploadFiles(pbFiles)
   })
 } else {
   var files = []

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "execspawn": "^1.0.1",
     "ghreleases": "^3.0.2",
     "github-from-package": "0.0.0",
+    "glob": "^7.1.6",
     "minimist": "^1.1.2",
     "mkdirp": "^0.5.1",
     "napi-build-utils": "^1.0.1",


### PR DESCRIPTION
A small change to fix #245, based on the [last comment](https://github.com/prebuild/prebuild/issues/245#issuecomment-471728217) there. This adds an extra dependency on glob, but it's already a transitive dependency anyway.

Rather than do just one level (all that's strictly necessary to make namespaced packages work) this is recursive, so it flattens the tree and uploads every file in `./prebuilds`. Happy to debate that, but I think it more accurately matches the documented behaviour of `upload-all`:

> upload all files from ./prebuilds folder to github