### PR TITLE
Update documentation for Node-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # prebuild
 
-> A command line tool for easily making prebuilt binaries for multiple versions of [Node.js](https://nodejs.org/en/), [N-API](https://nodejs.org/api/n-api.html), [Electron](http://electron.atom.io/) and [NW.js](https://nwjs.io/) on a specific platform.
+> A command line tool for easily making prebuilt binaries for multiple versions of [Node.js](https://nodejs.org/en/), [Node-API](https://nodejs.org/api/n-api.html#n_api_node_api), [Electron](http://electron.atom.io/) and [NW.js](https://nwjs.io/) on a specific platform.
 
 ```
 $ npm install -g prebuild
@@ -15,7 +15,7 @@ $ npm install -g prebuild
 
 ## Features
 
-* Builds native modules for any version of Node.js, N-API, Electron or NW.js, without having to switch between different versions to do so. This works by only downloading the correct headers and telling `node-gyp` to use those instead of the ones installed on your system.
+* Builds native modules for any version of Node.js, Node-API, Electron or NW.js, without having to switch between different versions to do so. This works by only downloading the correct headers and telling `node-gyp` to use those instead of the ones installed on your system.
 * Upload (`--upload`) prebuilt binaries to GitHub.
 * Support for stripping (`--strip`) debug information. Strip command defaults to `strip` but can be overridden by the `STRIP` environment variable.
 * Install prebuilt modules via [`prebuild-install`](https://github.com/prebuild/prebuild-install).
@@ -36,7 +36,7 @@ Alternatively, to build for some specific versions you can do:
 prebuild -t 0.10.42 -t 0.12.10 -t 4.3.0
 ```
 
-To build for N-API, do:
+To build for Node-API, do:
 
 ```
 prebuild -t 3 -r napi
@@ -136,11 +136,11 @@ To create a token:
 
 The default scopes should be fine.
 
-## N-API Considerations
+## Node-API Considerations
 
-### Declaring Supported N-API Versions
+### Declaring Supported Node-API Versions
 
-Native modules that are designed to work with [N-API](https://nodejs.org/api/n-api.html) must explicitly declare the N-API version(s) against which they can build. This is accomplished by including a `binary` property on the module's `package.json` file. For example:
+Native modules that are designed to work with [Node-API](https://nodejs.org/api/n-api.html#n_api_node_api), which was previously known as N-API, must explicitly declare the Node-API version(s) against which they can build. This is accomplished by including a `binary` property on the module's `package.json` file. For example:
 
 ```json
 "binary": {
@@ -148,19 +148,19 @@ Native modules that are designed to work with [N-API](https://nodejs.org/api/n-a
 }
 ```
 
-In the absence of a need to compile against a specific N-API version, the value `3` is a good choice as this is the N-API version that was supported when N-API left experimental status. 
+In the absence of a need to compile against a specific Node-API version, the value `3` is a good choice as this is the Node-API version that was supported when Node-API left experimental status. 
 
-Modules that are built against a specific N-API version will continue to operate indefinitely, even as later versions of N-API are introduced. 
+Modules that are built against a specific Node-API version will continue to operate indefinitely, even as later versions of Node-API are introduced. 
 
 ### Defining the `NAPI_VERSION` Value
 
-The N-API header files supplied with Node use the `NAPI_VERSION` preprocessor value supplied by the user to configure each build to the specific N-API version for which the native addon is being built. In addition, the module's C/C++ code can use this value to conditionally compile code based on the N-API version it is being compiled against.
+The Node-API header files supplied with Node use the `NAPI_VERSION` preprocessor value supplied by the user to configure each build to the specific Node-API version for which the native addon is being built. In addition, the module's C/C++ code can use this value to conditionally compile code based on the Node-API version it is being compiled against.
 
 `prebuild` supports two build backends: [`node-gyp`](https://github.com/nodejs/node-gyp) and [`cmake-js`](https://github.com/cmake-js/cmake-js). The `NAPI_VERSION` value is configured differently for each backend. 
 
 #### node-gyp
 
-The following code must be included in the `binding.gyp` file of modules targeting N-API:
+The following code must be included in the `binding.gyp` file of modules targeting Node-API:
 
 ```json
 "defines": [
@@ -170,7 +170,7 @@ The following code must be included in the `binding.gyp` file of modules targeti
 
 #### cmake-js
 
-The following line must be included in the `CMakeLists.txt` file of modules targeting N-API:
+The following line must be included in the `CMakeLists.txt` file of modules targeting Node-API:
 
 ```cmake
 add_compile_definitions(NAPI_VERSION=${napi_build_version})
@@ -178,9 +178,9 @@ add_compile_definitions(NAPI_VERSION=${napi_build_version})
 
 ### `prebuild` arguments
 
-The `--runtime` argument must be `napi` to request N-API builds. When requesting N-API builds, the module's `package.json` file _must_ include a `binary` property as described above. And the `binding.gyp` file _must_ include a define for `NAPI_VERSION` as described above.
+The `--runtime` argument must be `napi` to request Node-API builds. When requesting Node-API builds, the module's `package.json` file _must_ include a `binary` property as described above. And the `binding.gyp` file _must_ include a define for `NAPI_VERSION` as described above.
 
-One or more `--target` arguments may be specified to request builds for specific N-API versions. N-API versions are positive integer values. Alternatively, `--all` may be used to request builds for all N-API versions supported by the module. 
+One or more `--target` arguments may be specified to request builds for specific Node-API versions. Node-API versions are positive integer values. Alternatively, `--all` may be used to request builds for all Node-API versions supported by the module. 
 
 In the absence of both `--target` and `--all` arguments, `prebuild` will build the most current version of the module supported by the Node instance performing the build. 
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "devops",
     "electron",
     "node-webkit",
-    "n-api"
+    "node-api"
   ],
   "dependencies": {
     "cmake-js": "~5.2.0",


### PR DESCRIPTION
The Node.js core technology supporting the implementation on native add-ons previously known as **N-API** has been renamed to **Node-API** to make the name more appropriate and descriptive. This PR updates the project's documentation to reflect this change.