### PR TITLE
Cmake is producing a clean build everytime

### DIFF
--- a/cmakebuild.js
+++ b/cmakebuild.js
@@ -5,7 +5,7 @@ function runCmake (opts, target, cb) {
   which('cmake-js', function (err, cmakeJsPath) {
     if (err) return cb(err)
 
-    var args = ['rebuild']
+    var args = ['build']
     if (opts.runtime !== 'napi') args.push('--runtime-version=' + target)
     args.push('--arch=' + opts.arch)
     if (opts.runtime !== 'napi') args.push('--runtime=' + opts.runtime)


### PR DESCRIPTION
cmakebuild.js is hardcoded to 'rebuild', which cleans all build artifacts beforhand.  This is problematic for incremental builds in CI.  This hardcodes it to 'build' instead