### PR TITLE
Support stripping multiple files

### DIFF
--- a/prebuild.js
+++ b/prebuild.js
@@ -51,7 +51,7 @@ function prebuild (opts, target, runtime, callback) {
 
     if (opts.strip) {
       tasks.splice(1, 0, function (filenames, cb) {
-        buildLog('Stripping debug information from ' + filenames)
+        buildLog('Stripping debug information from ' + filenames.join(', '))
         strip(filenames, function (err) {
           if (err) return cb(err)
           cb(null, filenames)

--- a/prebuild.js
+++ b/prebuild.js
@@ -50,11 +50,11 @@ function prebuild (opts, target, runtime, callback) {
     ]
 
     if (opts.strip) {
-      tasks.splice(1, 0, function (filename, cb) {
-        buildLog('Stripping debug information from ' + filename)
-        strip(filename, function (err) {
+      tasks.splice(1, 0, function (filenames, cb) {
+        buildLog('Stripping debug information from ' + filenames)
+        strip(filenames, function (err) {
           if (err) return cb(err)
-          cb(null, filename)
+          cb(null, filenames)
         })
       })
     }

--- a/strip.js
+++ b/strip.js
@@ -1,10 +1,27 @@
 var util = require('./util')
 
-function strip (file, cb) {
+function strip (files, cb) {
   // TODO no support on windows, noop
   var platform = util.platform()
   if (platform === 'win32') return process.nextTick(cb)
-  util.spawn(process.env.STRIP || 'strip', stripArgs(platform, file), cb)
+
+  stripFiles(files, platform, cb)
+}
+
+function stripFiles (files, platform, cb) {
+  if (files.length === 0) {
+    process.nextTick(cb)
+    return
+  }
+
+  util.spawn(process.env.STRIP || 'strip', stripArgs(platform, files[0]), function (err) {
+    if (err) {
+      cb(err)
+      return
+    }
+
+    stripFiles(files.slice(1), platform, cb)
+  })
 }
 
 function stripArgs (platform, file) {

--- a/test/strip-test.js
+++ b/test/strip-test.js
@@ -9,7 +9,7 @@ test('strip is noop on windows', function (t) {
   }
   var _platform = util.platform
   util.platform = function () { return 'win32' }
-  strip('foo.node', function (err) {
+  strip(['foo.node'], function (err) {
     util.spawn = _spawn
     util.platform = _platform
     t.error(err, 'no error')
@@ -27,7 +27,7 @@ test('strip gets special args for darwin', function (t) {
   }
   var _platform = util.platform
   util.platform = function () { return 'darwin' }
-  strip('foo.node', function (err) {
+  strip(['foo.node'], function (err) {
     util.spawn = _spawn
     util.platform = _platform
     t.error(err, 'no error')
@@ -45,7 +45,7 @@ test('strip gets special args for linux', function (t) {
   }
   var _platform = util.platform
   util.platform = function () { return 'linux' }
-  strip('foo.node', function (err) {
+  strip(['foo.node'], function (err) {
     util.spawn = _spawn
     util.platform = _platform
     t.error(err, 'no error')
@@ -63,7 +63,29 @@ test('strip gets empty args for other', function (t) {
   }
   var _platform = util.platform
   util.platform = function () { return 'sunos' }
-  strip('foo.node', function (err) {
+  strip(['foo.node'], function (err) {
+    util.spawn = _spawn
+    util.platform = _platform
+    t.error(err, 'no error')
+    t.end()
+  })
+})
+
+test('strip gets special args for linux on multiple files', function (t) {
+  t.plan(5)
+  const collectedFiles = ['foo.node', 'bar.node']
+  var currentFileIndex = 0
+  var _spawn = util.spawn
+  util.spawn = function (cmd, args, cb) {
+    t.equal(cmd, 'strip', 'correct cmd')
+    const expectedFile = collectedFiles[currentFileIndex]
+    t.deepEqual(args, [expectedFile, '--strip-all'], 'correct args')
+    process.nextTick(cb)
+    currentFileIndex++
+  }
+  var _platform = util.platform
+  util.platform = function () { return 'linux' }
+  strip(collectedFiles, function (err) {
     util.spawn = _spawn
     util.platform = _platform
     t.error(err, 'no error')


### PR DESCRIPTION
As I was trying to change [the `--include-regex` parameter to include multiple files](https://github.com/desktop/desktop-trampoline/blob/8b38cd56a192f423b0e89121641f8526b86ed627/package.json#L18-L20) in the prebuild bundle, while preserving the `--strip` parameter, I noticed `strip` wasn't prepared to receive an array of files (which is what `collect` generates, even when it's only 1 file). In the end, the `spawn` function received an args parameter that looked like this: `[ [ 'build/Release/desktop-trampoline' ], '-Sx' ]`

This PR changes `strip` to accept multiple files, and processes those files sequentially.