### PR TITLE
Upgrade to version 2 of detect-libc

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "cmake-js": "~5.2.0",
-    "detect-libc": "^1.0.3",
+    "detect-libc": "^2.0.0",
     "each-series-async": "^1.0.1",
     "execspawn": "^1.0.1",
     "ghreleases": "^3.0.2",

--- a/rc.js
+++ b/rc.js
@@ -3,7 +3,7 @@ var targets = require('node-abi').supportedTargets
 var detectLibc = require('detect-libc')
 var napi = require('napi-build-utils')
 
-var libc = process.env.LIBC || (detectLibc.isNonGlibcLinux && detectLibc.family) || ''
+var libc = process.env.LIBC || (detectLibc.isNonGlibcLinuxSync() && detectLibc.familySync()) || ''
 
 var rc = require('rc')('prebuild', {
   target: process.versions.node,


### PR DESCRIPTION
Hello, this is the "sibling" change for the approved https://github.com/prebuild/prebuild-install/pull/166 and should also be considered `semver-patch` as `prebuild` currently requires Node.js >= 10.

The change in this PR can be published independently of the `prebuild-install` change.