### PR TITLE
Fix electron headers download url

### DIFF
--- a/gypbuild.js
+++ b/gypbuild.js
@@ -18,7 +18,7 @@ function runGyp (opts, target, cb) {
   args.push('--target_arch=' + opts.arch)
   if (opts.runtime === 'electron') {
     args.push('--runtime=electron')
-    args.push('--dist-url=https://atom.io/download/electron')
+    args.push('--dist-url=https://electronjs.org/headers')
   } else if (opts.runtime === 'node-webkit') {
     args.push('--runtime=node-webkit')
   } else if (opts.runtime === 'node') {


### PR DESCRIPTION
According to [this blog post](https://www.electronjs.org/blog/s3-bucket-change), the S3 bucket that used to store electron artifacts has been abandoned. The URL which prebuild script currently uses (`https://atom.io/download/electron`) continues to point to that abandoned bucket. Starting from electron v19, the builds [will fail](https://github.com/m4heshd/better-sqlite3-multiple-ciphers/runs/7163185059?check_suite_focus=true#step:5:12) if the deprecated URL is used.

As advised in [the official documentation](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules#manually-building-for-electron), this PR changes the above mentioned URL to `https://electronjs.org/headers`, fixing errors regarding to builds starting from electron v19. This URL also does not have any issues with backwards compatibility.

**Note:**
As mentioned on the blog post, URL `https://artifacts.electronjs.org/headers/dist` also can be used but decided to use the URL mentioned in the official documentation since it points to this URL anyways and the bucket URL and structure can be subjected to any changes in the near future.