### PR TITLE
Add support for Node.js 20, drop support for Node.js 10 and 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 16, 14, 12, 10]
+        node: [20, 18, 16, 14]
         os: [windows-2019, macos-11, ubuntu-20.04]
         arch: [x64]
         include:
+          - os: windows-2019
+            arch: x86
+            node: 20
           - os: windows-2019
             arch: x86
             node: 18
@@ -26,12 +29,6 @@ jobs:
           - os: windows-2019
             arch: x86
             node: 14
-          - os: windows-2019
-            arch: x86
-            node: 12
-          - os: windows-2019
-            arch: x86
-            node: 10
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
@@ -40,13 +37,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
-        # See https://github.com/nodejs/node-gyp/issues/1574#issuecomment-554187531
-      - name: Configure macOS env
-        run: |
-          echo "CXXFLAGS=-mmacosx-version-min=10.9" >> $GITHUB_ENV
-          echo "LDFLAGS=-mmacosx-version-min=10.9" >> $GITHUB_ENV
-        if: ${{ startsWith(matrix.os, 'macos') }}
+          python-version: "3.11"
       - name: Use Node.js ${{ matrix.node }}
         uses: actions/setup-node@v3
         with:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,6 @@ $ npm install -g prebuild
 
 [![npm](https://img.shields.io/npm/v/prebuild.svg)](https://www.npmjs.com/package/prebuild)
 ![Node version](https://img.shields.io/node/v/prebuild.svg)
-[![build status](http://img.shields.io/travis/prebuild/prebuild.svg?style=flat)](http://travis-ci.org/prebuild/prebuild)
-[![Build status](https://ci.appveyor.com/api/projects/status/oy1kk4fpy51net0v/branch/master?svg=true)](https://ci.appveyor.com/project/mathiask88/prebuild)
-[![david](https://david-dm.org/prebuild/prebuild.svg)](https://david-dm.org/prebuild/prebuild)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 ## Features

--- a/pack.js
+++ b/pack.js
@@ -1,7 +1,6 @@
 var eachSeries = require('each-series-async')
 var fs = require('fs')
 var path = require('path')
-var mkdirp = require('mkdirp')
 var tar = require('tar-stream')
 var zlib = require('zlib')
 
@@ -10,7 +9,7 @@ function mode (octal) {
 }
 
 function pack (filenames, tarPath, cb) {
-  mkdirp(path.dirname(tarPath), function () {
+  fs.mkdir(path.dirname(tarPath), { recursive: true }, function () {
     if (!Array.isArray(filenames)) {
       filenames = [filenames]
     }

--- a/package.json
+++ b/package.json
@@ -21,32 +21,31 @@
     "node-api"
   ],
   "dependencies": {
-    "cmake-js": "~6.3.0",
-    "detect-libc": "^2.0.0",
+    "cmake-js": "^7.2.1",
+    "detect-libc": "^2.0.1",
     "each-series-async": "^1.0.1",
     "execspawn": "^1.0.1",
     "ghreleases": "^3.0.2",
     "github-from-package": "0.0.0",
-    "glob": "^7.1.6",
-    "minimist": "^1.1.2",
-    "mkdirp": "^0.5.1",
-    "napi-build-utils": "^1.0.1",
-    "node-abi": "^3.0.0",
-    "node-gyp": "^6.0.1",
-    "node-ninja": "^1.0.1",
-    "noop-logger": "^0.1.0",
+    "glob": "^7.2.3",
+    "minimist": "^1.2.8",
+    "napi-build-utils": "^1.0.2",
+    "node-abi": "^3.45.0",
+    "node-gyp": "^9.4.0",
+    "node-ninja": "^1.0.2",
+    "noop-logger": "^0.1.1",
     "npm-which": "^3.0.1",
-    "npmlog": "^4.0.1",
-    "nw-gyp": "^3.6.3",
-    "rc": "^1.0.3",
-    "run-waterfall": "^1.1.6",
-    "tar-stream": "^2.1.0"
+    "npmlog": "^7.0.1",
+    "nw-gyp": "^3.6.6",
+    "rc": "^1.2.8",
+    "run-waterfall": "^1.1.7",
+    "tar-stream": "^3.1.6"
   },
   "devDependencies": {
     "a-native-module": "^1.0.0",
-    "rimraf": "^3.0.0",
-    "standard": "^13.0.1",
-    "tape": "^4.0.1"
+    "rimraf": "^4.4.1",
+    "standard": "^14.3.4",
+    "tape": "^5.6.4"
   },
   "bin": {
     "prebuild": "./bin.js"
@@ -69,6 +68,6 @@
   },
   "homepage": "https://github.com/prebuild/prebuild",
   "engines": {
-    "node": ">=10"
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
   }
 }

--- a/test/gypbuild-test.js
+++ b/test/gypbuild-test.js
@@ -9,10 +9,12 @@ var os = require('os')
 test('gyp is invoked with correct arguments, release mode', function (t) {
   t.plan(7)
   var opts = {
-    pkg: { binary: {
-      module_name: 'module_name',
-      module_path: 'module_path'
-    } },
+    pkg: {
+      binary: {
+        module_name: 'module_name',
+        module_path: 'module_path'
+      }
+    },
     arch: 'fooarch',
     gyp: {
       parseArgv: function (args) {

--- a/test/integration-cmake-test.js
+++ b/test/integration-cmake-test.js
@@ -6,46 +6,37 @@ var rm = require('rimraf')
 
 var cwd = path.join(__dirname, 'native-module-cmake')
 
-// See https://github.com/cmake-js/cmake-js/issues/186
-if (process.platform !== 'win32' || process.arch !== 'ia32') {
-  test('can prebuild a cmake-js native module for node', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake-js native module for node', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
+})
 
-  test('can prebuild a cmake-js native module for electron', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-electron-v50-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild-electron', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake-js native module for electron', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-electron-v50-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  exec('npm run prebuild-electron', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
+})
 
-  test('can prebuild a cmake-js native module for node with silent argument', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild-silent', { cwd: cwd }, function (error, stdout, stderr) {
-      // XXX: latest cmake-js has a forgotten console.log(process.argv)
-      t.ok(stdout.trim().split('\n').length <= 12, 'stdout should be silent')
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake-js native module for node with silent argument', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  exec('npm run prebuild-silent', { cwd: cwd }, function (error, stdout, stderr) {
+    // XXX: latest cmake-js has a forgotten console.log(process.argv)
+    t.ok(stdout.trim().split('\n').length <= 12, 'stdout should be silent')
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
-}
+})

--- a/test/integration-gyp-test.js
+++ b/test/integration-gyp-test.js
@@ -10,8 +10,6 @@ test('can prebuild a gyp native module for node', function (t) {
   rm.sync(path.join(cwd, 'prebuilds'))
   var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
   var prebuild = path.join(cwd, 'prebuilds', file)
-  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-  console.log()
   exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
     t.equal(error, null)
     t.equal(fs.existsSync(prebuild), true)
@@ -23,8 +21,6 @@ test('can prebuild a gyp native module for electron', function (t) {
   rm.sync(path.join(cwd, 'prebuilds'))
   var file = 'native-v1.0.0-electron-v50-' + process.platform + '-' + process.arch + '.tar.gz'
   var prebuild = path.join(cwd, 'prebuilds', file)
-  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-  console.log()
   exec('npm run prebuild-electron', { cwd: cwd }, function (error, stdout, stderr) {
     t.equal(error, null)
     t.equal(fs.existsSync(prebuild), true)
@@ -36,8 +32,6 @@ test.skip('can prebuild a gyp native module for node-webkit', function (t) {
   rm.sync(path.join(cwd, 'prebuilds'))
   var file = 'native-v1.0.0-node-webkit-v59-' + process.platform + '-' + process.arch + '.tar.gz'
   var prebuild = path.join(cwd, 'prebuilds', file)
-  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-  console.log()
   exec('npm run prebuild-node-webkit', { cwd: cwd }, function (error, stdout, stderr) {
     t.equal(error, null)
     t.equal(fs.existsSync(prebuild), true)
@@ -49,8 +43,6 @@ test('can prebuild a gyp native module for node with prepack script', function (
   rm.sync(path.join(cwd, 'prebuilds'))
   var file = 'native-v1.0.0-node-v57-' + process.platform + '-' + process.arch + '.tar.gz'
   var prebuild = path.join(cwd, 'prebuilds', file)
-  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-  console.log()
   exec('npm run prebuild-prepack', { cwd: cwd }, function (error, stdout, stderr) {
     t.equal(error, null)
     t.equal(fs.existsSync(prebuild), true)

--- a/test/integration-napi-cmake-test.js
+++ b/test/integration-napi-cmake-test.js
@@ -6,31 +6,24 @@ var rm = require('rimraf')
 
 var cwd = path.join(__dirname, 'native-module-napi-cmake')
 
-// See https://github.com/cmake-js/cmake-js/issues/186
-if (process.platform !== 'win32' || process.arch !== 'ia32') {
-  test('can prebuild a cmake napi module for node', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake napi module for node', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
+})
 
-  test('can prebuild a cmake napi module for node with prepack script', function (t) {
-    rm.sync(path.join(cwd, 'prebuilds'))
-    var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
-    var prebuild = path.join(cwd, 'prebuilds', file)
-    // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-    console.log()
-    exec('npm run prebuild-prepack', { cwd: cwd }, function (error, stdout, stderr) {
-      t.equal(error, null)
-      t.equal(fs.existsSync(prebuild), true)
-      t.end()
-    })
+test('can prebuild a cmake napi module for node with prepack script', function (t) {
+  rm.sync(path.join(cwd, 'prebuilds'))
+  var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
+  var prebuild = path.join(cwd, 'prebuilds', file)
+  exec('npm run prebuild-prepack', { cwd: cwd }, function (error, stdout, stderr) {
+    t.equal(error, null)
+    t.equal(fs.existsSync(prebuild), true)
+    t.end()
   })
-}
+})

--- a/test/integration-napi-gyp-test.js
+++ b/test/integration-napi-gyp-test.js
@@ -10,8 +10,6 @@ test('can prebuild a gyp napi module for node', function (t) {
   rm.sync(path.join(cwd, 'prebuilds'))
   var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
   var prebuild = path.join(cwd, 'prebuilds', file)
-  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-  console.log()
   exec('npm run prebuild', { cwd: cwd }, function (error, stdout, stderr) {
     t.equal(error, null)
     t.equal(fs.existsSync(prebuild), true)
@@ -23,8 +21,6 @@ test('can prebuild a gyp napi module for node with prepack script', function (t)
   rm.sync(path.join(cwd, 'prebuilds'))
   var file = 'native-v1.0.0-napi-v1-' + process.platform + '-' + process.arch + '.tar.gz'
   var prebuild = path.join(cwd, 'prebuilds', file)
-  // A quick, temporary fix for a node.js bug (https://github.com/prebuild/prebuild/pull/208#issuecomment-361108755)
-  console.log()
   exec('npm run prebuild-prepack', { cwd: cwd }, function (error, stdout, stderr) {
     t.equal(error, null)
     t.equal(fs.existsSync(prebuild), true)

--- a/test/native-module-gyp/binding.gyp
+++ b/test/native-module-gyp/binding.gyp
@@ -7,7 +7,10 @@
       'target_name': 'native',
       'sources': [
         'src/native.cc',
-      ]
+      ],
+      'xcode_settings': {
+        'MACOSX_DEPLOYMENT_TARGET': '10.9'
+      }
     }
   ]
 }

--- a/test/native-module-napi-cmake/CMakeLists.txt
+++ b/test/native-module-napi-cmake/CMakeLists.txt
@@ -9,3 +9,8 @@ file(GLOB SOURCE_FILES "src/native.cc")
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${CMAKE_JS_SRC})
 set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 target_link_libraries(${PROJECT_NAME} ${CMAKE_JS_LIB})
+
+if(MSVC AND CMAKE_JS_NODELIB_DEF AND CMAKE_JS_NODELIB_TARGET)
+  # Generate node.lib
+  execute_process(COMMAND ${CMAKE_AR} /def:${CMAKE_JS_NODELIB_DEF} /out:${CMAKE_JS_NODELIB_TARGET} ${CMAKE_STATIC_LINKER_FLAGS})
+endif()

--- a/test/native-module-napi-gyp/binding.gyp
+++ b/test/native-module-napi-gyp/binding.gyp
@@ -7,7 +7,10 @@
       ],
       'defines': [
         'NAPI_VERSION=<(napi_build_version)',
-      ]
+      ],
+      'xcode_settings': {
+        'MACOSX_DEPLOYMENT_TARGET': '10.9'
+      }
     }
   ]
 }


### PR DESCRIPTION
This is a semver major change, please see https://github.com/prebuild/prebuild/issues/286 for discussion and details.

It also:

- Upgrades all dependencies to their most recent version that still supports Node.js 14.
- Synchronises the `engines.node` property with that of the latest `node-gyp` we're upgrading to.
- Ensures all tests run on all platforms as I noticed some of the cmake-js tests were optionally being skipped.
- Ensures the `native-module-napi-cmake` test includes the CMake config required for use with Node-API.
- Removes the no-longer-required `mkdirp` dependency as Node.js has provided this feature since version 10.
- Removes unused CI "badges" from the readme

Additions based on feedback:

- Defines deployment target in test fixtures (rather than CI config) so tests can be run locally on macOS
