### PR TITLE
Release v12.0.0, drops support for Node.js 10 and 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prebuild",
-  "version": "11.0.4",
+  "version": "12.0.0",
   "description": "A command line tool for easily making prebuilt binaries for multiple versions of node, electron or node-webkit on a specific platform",
   "scripts": {
     "test": "tape test && npm run lint",
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "cmake-js": "^7.2.1",
-    "detect-libc": "^2.0.1",
+    "detect-libc": "^2.0.2",
     "each-series-async": "^1.0.1",
     "execspawn": "^1.0.1",
     "ghreleases": "^3.0.2",
@@ -30,7 +30,7 @@
     "glob": "^7.2.3",
     "minimist": "^1.2.8",
     "napi-build-utils": "^1.0.2",
-    "node-abi": "^3.45.0",
+    "node-abi": "^3.47.0",
     "node-gyp": "^9.4.0",
     "node-ninja": "^1.0.2",
     "noop-logger": "^0.1.1",
@@ -45,7 +45,7 @@
     "a-native-module": "^1.0.0",
     "rimraf": "^4.4.1",
     "standard": "^14.3.4",
-    "tape": "^5.6.4"
+    "tape": "^5.6.6"
   },
   "bin": {
     "prebuild": "./bin.js"


### PR DESCRIPTION
- https://github.com/prebuild/prebuild/pull/291
- https://github.com/prebuild/prebuild/pull/304