### PR TITLE
Add prerelease option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ You can use `prebuild --upload-all` to upload all files from the `./prebuilds` f
 
 You can use `prebuild --upload --tag-prefix <prefix>` for specific tag prefixes for the release. The default prefix is `v` and will result in a tag with an appended version number, for example `v1.0.0`. For [lerna](https://github.com/lerna/lerna) you can use the package name e.g. `prebuild --tag-prefix some-package@` and the binaries will be released on the appropriate package's tags, for example `some-package@1.0.0`.
 
+You can use `prebuild --upload --prerelease` to create a prerelease, which will not be shown as the latest release.
+
 ## Create GitHub Token
 
 A GitHub token is needed for two reasons:

--- a/help.txt
+++ b/help.txt
@@ -7,6 +7,7 @@ prebuild [options]
   --upload      -u  [gh-token]  (upload prebuilds to github)
   --upload-all  -u  [gh-token]  (upload all files from ./prebuilds folder to github)
   --tag-prefix <prefix>         (github tag prefix, default is "v")
+  --prerelease                  (identify the github release as a prerelease)
   --preinstall  -i  script      (run this script before prebuilding)
   --prepack     -c  script      (run this script before packing, can be used to codesign)
   --path        -p  path        (make a prebuild here)

--- a/rc.js
+++ b/rc.js
@@ -19,7 +19,8 @@ var rc = require('rc')('prebuild', {
   backend: 'node-gyp',
   format: false,
   'include-regex': '\\.node$',
-  'tag-prefix': 'v'
+  'tag-prefix': 'v',
+  prerelease: false
 }, minimist(process.argv, {
   alias: {
     target: 't',

--- a/test/rc-test.js
+++ b/test/rc-test.js
@@ -18,7 +18,8 @@ test('custom config and aliases', function (t) {
     '--target 13',
     '--runtime electron',
     '--libc testlibc',
-    '--format msvs'
+    '--format msvs',
+    '--prerelease'
   ]
   runRc(t, args.join(' '), {}, function (rc) {
     t.equal(rc.all, false, 'default is not building all targets')
@@ -47,6 +48,7 @@ test('custom config and aliases', function (t) {
     t.equal(rc.libc, 'testlibc', 'libc family')
     t.equal(rc.format, 'msvs', 'correct node-gyp format')
     t.equal(rc['tag-prefix'], 'v', 'correct default tag prefix')
+    t.equal(rc.prerelease, true, 'prerelease is set')
     t.end()
   })
 })

--- a/test/upload-test.js
+++ b/test/upload-test.js
@@ -9,8 +9,8 @@ test('uploading to GitHub, basic use case', function (t) {
   })
 })
 
-test('uploading to GitHub, tag prefix', function (t) {
-  upload(basicSetup(t, { tagPrefix: `${pkg.name}@` }), function (err) {
+test('uploading to GitHub, tag prefix, prerelease', function (t) {
+  upload(basicSetup(t, { tagPrefix: `${pkg.name}@`, prerelease: true }), function (err) {
     t.error(err, 'no error')
     t.end()
   })
@@ -68,18 +68,20 @@ function basicSetup (t, opts) {
   opts = opts || {}
   const assets = opts.assets || []
   const tagPrefix = opts.tagPrefix || 'v'
+  const prerelease = opts.prerelease || false
   var files = ['foo.tar.gz', 'bar.tar.gz', 'baz.tar.gz']
   return {
     pkg: pkg,
     upload: 't000k3n',
     files: files,
     'tag-prefix': tagPrefix,
+    prerelease,
     gh: {
       create: function (auth, user, repo, opts, cb) {
         t.deepEqual(auth, { user: 'x-oauth', token: 't000k3n' }, 'correct auth')
         t.equal(user, 'ralphtheninja', 'correct user')
         t.equal(repo, 'a-native-module', 'correct repo')
-        t.deepEqual(opts, { tag_name: `${tagPrefix}${pkg.version}` }, 'correct opts')
+        t.deepEqual(opts, { tag_name: `${tagPrefix}${pkg.version}`, prerelease }, 'correct opts')
         process.nextTick(cb)
       },
       getByTag: function (auth, user, repo, tag, cb) {

--- a/upload.js
+++ b/upload.js
@@ -20,8 +20,9 @@ function upload (opts, cb) {
   var repo = url.split('/')[4]
   var auth = { user: 'x-oauth', token: opts.upload }
   var tag = `${tagPrefix}${pkg.version}`
+  var prerelease = opts.prerelease
 
-  gh.create(auth, user, repo, { tag_name: tag }, function () {
+  gh.create(auth, user, repo, { tag_name: tag, prerelease }, function () {
     gh.getByTag(auth, user, repo, tag, function (err, release) {
       if (err) return cb(err)
 


### PR DESCRIPTION
This is useful if you want to prevent a newly-created release being labelled by GitHub as "latest". The GitHub UI provides a checkbox to change this status later.

This is a simpler version of https://github.com/prebuild/prebuild/pull/127 that doesn't attempt to implement any semver logic, only the `--prerelease` option and associated tests, which will add the `prerelease` property to the underlying [GitHub API call](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release).

Fixes https://github.com/prebuild/prebuild/issues/126