### PR TITLE
Use arch instead of target_arch

### DIFF
--- a/gypbuild.js
+++ b/gypbuild.js
@@ -15,7 +15,7 @@ function runGyp (opts, target, cb) {
   } else {
     args.push('--target=' + target)
   }
-  args.push('--target_arch=' + opts.arch)
+  args.push('--arch=' + opts.arch)
   if (opts.runtime === 'electron') {
     args.push('--runtime=electron')
     args.push('--dist-url=https://electronjs.org/headers')

--- a/test/gypbuild-test.js
+++ b/test/gypbuild-test.js
@@ -18,7 +18,7 @@ test('gyp is invoked with correct arguments, release mode', function (t) {
     arch: 'fooarch',
     gyp: {
       parseArgv: function (args) {
-        t.deepEqual(args, ['node', 'index.js', 'rebuild', '--target=x.y.z', '--target_arch=fooarch'], 'correct arguments')
+        t.deepEqual(args, ['node', 'index.js', 'rebuild', '--target=x.y.z', '--arch=fooarch'], 'correct arguments')
       },
       commands: {
         rebuild: function (args, cb) {
@@ -61,7 +61,7 @@ test('gyp is invoked with correct arguments, debug mode', function (t) {
     debug: true,
     gyp: {
       parseArgv: function (args) {
-        t.deepEqual(args, ['node', 'index.js', 'rebuild', '--target=x.y.z', '--target_arch=fooarch', '--debug'], 'correct arguments')
+        t.deepEqual(args, ['node', 'index.js', 'rebuild', '--target=x.y.z', '--arch=fooarch', '--debug'], 'correct arguments')
       },
       commands: {
         rebuild: function (args, cb) {


### PR DESCRIPTION
When building for a different architecture using node-gyp, the arch option should be used. Using target_arch populates the variable usable in the binding.gyp file, but node-gyp will still do a build with the system's architecture.