### PR TITLE
Drop support for Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 18, 16, 14]
-        os: [windows-2019, macos-11, ubuntu-20.04]
+        node: [20, 18, 16]
+        os: [windows-2019, macos-11, ubuntu-22.04]
         arch: [x64]
         include:
           - os: windows-2019
@@ -26,9 +26,6 @@ jobs:
           - os: windows-2019
             arch: x86
             node: 16
-          - os: windows-2019
-            arch: x86
-            node: 14
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
   },
   "homepage": "https://github.com/prebuild/prebuild",
   "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+    "node": "^16.14.0 || >=18.0.0"
   }
 }


### PR DESCRIPTION
Even 16 is already EOL. Needed for upgrading node-gyp.