### PR TITLE
CI: Pin Node.js 18 on 32-bit Windows to use npm 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
             node: 20
           - os: windows-2019
             arch: x86
-            node: 18
+            node: "18.18.2" # pinned to avoid 18.19.0 and npm 10
           - os: windows-2019
             arch: x86
             node: 16


### PR DESCRIPTION
There's an intermittent problem with the specific combo of npm 10 + Node.js 18 + 32-bit Windows where running `npm install` opens thousands of network connections, leading to resource starvation and a process crash.

This PR pins the 32-bit Windows Node.js 18 CI job to the most recent version that ships with npm 9, which is the same approach as I'm using in sharp - see https://github.com/lovell/sharp/commit/420e0822b4631aa8187af7600d340180aeb37afe