### PR TITLE
Update cmakebuild.js to spawn with `shell: true`

### DIFF
--- a/cmakebuild.js
+++ b/cmakebuild.js
@@ -24,7 +24,7 @@ function runCmake (opts, target, cb) {
       }
     }
 
-    var proc = spawn(cmakeJsPath, args, { shell: true })
+    var proc = spawn(cmakeJsPath, args, process.platform === "win32" ? { shell: true } : undefined)
     proc.stdout.pipe(process.stdout)
     proc.stderr.pipe(process.stderr)
     proc.on('exit', function (code) {

--- a/cmakebuild.js
+++ b/cmakebuild.js
@@ -24,7 +24,7 @@ function runCmake (opts, target, cb) {
       }
     }
 
-    var proc = spawn(cmakeJsPath, args, process.platform === "win32" ? { shell: true } : undefined)
+    var proc = spawn(cmakeJsPath, args, process.platform === 'win32' ? { shell: true } : undefined)
     proc.stdout.pipe(process.stdout)
     proc.stderr.pipe(process.stderr)
     proc.on('exit', function (code) {

--- a/cmakebuild.js
+++ b/cmakebuild.js
@@ -24,7 +24,7 @@ function runCmake (opts, target, cb) {
       }
     }
 
-    var proc = spawn(cmakeJsPath, args)
+    var proc = spawn(cmakeJsPath, args, { shell: true })
     proc.stdout.pipe(process.stdout)
     proc.stderr.pipe(process.stderr)
     proc.on('exit', function (code) {


### PR DESCRIPTION
This fixes #324 - I've tested on a Windows x86_64 and on my MacBook M3 (arm64).

I considered adding it here as well: https://github.com/prebuild/prebuild/blob/af905c75861d6692d63ef3cc386a7682b41a0941/util.js#L20

But it seems the only code (currently) calling this of that util is disabled on Windows: https://github.com/prebuild/prebuild/blob/af905c75861d6692d63ef3cc386a7682b41a0941/strip.js#L6